### PR TITLE
Update putCollection.sql

### DIFF
--- a/putCollection.sql
+++ b/putCollection.sql
@@ -1,3 +1,3 @@
 INSERT INTO $1~ (id, doc, created) VALUES ($2, $3, now())
-  ON CONFLICT (id) DO UPDATE SET doc=$2
+  ON CONFLICT (id) DO UPDATE SET doc=excluded.id
   RETURNING id, doc;


### PR DESCRIPTION
the right way to do ON CONFLICT updates.

without it you are setting the same `id` value on all conflicts.
